### PR TITLE
Force stratos to use SSL to db

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -131,6 +131,7 @@ jobs:
             CF_CLIENT: stratos
             CF_CLIENT_SECRET: ((dev-cf-client-secret))
             SESSION_STORE_SECRET: ((dev-session-store-secret))
+            DB_SSL_MODE: "verify-ca" 
     on_failure:
       put: slack
       params:


### PR DESCRIPTION
## Changes proposed in this pull request:
- After upgrading to PostgreSQL 15 found that by default traffic needs to use SSL.  This forces the deployment of stratos to use ssl and the root ca already colocated in the trusted keystore of CF.  Verified in dev and ran a `SELECT * from pg_stat_ssl` to verify.
- Part of https://github.com/cloud-gov/private/issues/2034
-

## Security considerations
Forces SSL to RDS db
