### PR TITLE
SSL now for stage and prod

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -182,6 +182,7 @@ jobs:
             CF_CLIENT: stratos
             CF_CLIENT_SECRET: ((staging-cf-client-secret))
             SESSION_STORE_SECRET: ((staging-session-store-secret))
+            DB_SSL_MODE: "verify-ca" 
       - put: cf-staging
         # This can eventually be removed, once we're sure nobody is linking to
         # dashboard-beta.
@@ -244,6 +245,7 @@ jobs:
             CF_CLIENT: stratos
             CF_CLIENT_SECRET: ((production-cf-client-secret))
             SESSION_STORE_SECRET: ((production-session-store-secret))
+            DB_SSL_MODE: "verify-ca" 
       - put: cf-production
         # This can eventually be removed, once we're sure nobody is linking to
         # dashboard-beta.


### PR DESCRIPTION
## Changes proposed in this pull request:
- After upgrading to PostgreSQL 15 found that by default traffic needs to use SSL.  This forces the deployment of stratos to use ssl and the root ca already colocated in the trusted keystore of CF.  Verified in dev and ran a `SELECT * from pg_stat_ssl` to verify.
- Swear I saw a yaml anchor from dev to stage/prod, must have imagined it, this change is for stage and prod
- Part of https://github.com/cloud-gov/private/issues/2034
-

## Security considerations
Forces SSL to RDS db
