### PR TITLE
remove obsolete param for resource fetching stratos source code

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -13,8 +13,6 @@ jobs:
       - in_parallel:
         - get: stratos-source
           trigger: true
-          params:
-            include_source_tarball: true
         - get: config
           passed: [set-self]
           trigger: true


### PR DESCRIPTION
## Changes proposed in this pull request:

- remove obsolete param for resource fetching stratos source code
-
-

## security considerations

None. This parameter is no longer supported and was causing build issues
